### PR TITLE
Correct the include path for package managers

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -1,6 +1,7 @@
 {
     "user": "AmyrAhmady",
     "repo": "samp-plugin-crashdetect",
+    "include_path": "include",
     "resources": [
         {
             "name": "^crashdetect-(.*)-linux.tar.gz$",


### PR DESCRIPTION
Include path has been incorrectly removed in dab1bd9f64f65bc0982d085552db09c8a51dd1ed, which breaks the intendent behavior of package managers.
The `include_path` option is related to the structure of the source code, not the release.

sampctl source code:
```ts
IncludePath  string `json:"include_path,omitempty" yaml:"include_path,omitempty"` // include path within the repository, so users don't need to specify the path explicitly
```
https://github.com/Southclaws/sampctl/blob/e289d49a7aa9fdf2a6bd84b35fb2eac9c143ac16/pawnpackage/package.go#L73

